### PR TITLE
Make the clock support timezones and DST

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -33,4 +33,5 @@ lib_deps =
     bblanchon/ArduinoJson@^7.0.0
     lvgl/lvgl@>=9.1.0
     smfsw/Queue@1.11
+    rzeldent/micro-timezonedb@1.0.3
 	M5Dial-LVGL=https://github.com/aeroniemi/M5Dial-LVGL.git#v0.1.0

--- a/src/sys/aero_time.h
+++ b/src/sys/aero_time.h
@@ -1,4 +1,5 @@
 #include <esp_sntp.h>
+#include <timezonedb_lookup.h>
 #include <WiFi.h>
 #include <M5Dial.h>
 #include "../secrets.h"
@@ -16,4 +17,6 @@ inline void setupTime()
     sntp_set_time_sync_notification_cb(sync_time_cb);
     sntp_set_sync_interval(12 * 60 * 60 * 1000UL);
     configTzTime(NTP_TIMEZONE, NTP_SERVER1, NTP_SERVER2, NTP_SERVER3);
+    setenv("TZ", lookup_posix_timezone_tz(NTP_TIMEZONE), 1);
+    tzset();
 }

--- a/src/ui/screens/Screen_Clock.cpp
+++ b/src/ui/screens/Screen_Clock.cpp
@@ -7,9 +7,10 @@ static constexpr const char *const month[12] = {"Jan", "Feb", "Mar", "Apr",
 void Screen_Clock::update_time(lv_timer_t *timer)
 {
     Screen_Clock *screen = (Screen_Clock *)timer->user_data;
-    auto dt = M5Dial.Rtc.getDateTime();
-    lv_label_set_text_fmt(screen->clock_text, "%02d:%02d:%02d", dt.time.hours, dt.time.minutes, dt.time.seconds);
-    lv_label_set_text_fmt(screen->date_text, "%s %d %s", weekday[dt.date.weekDay],dt.date.date, month[dt.date.month]);
+    time_t utc = time(nullptr);
+    tm * lt = localtime(&utc);
+    lv_label_set_text_fmt(screen->clock_text, "%02d:%02d:%02d", lt->tm_hour, lt->tm_min, lt->tm_sec);
+    lv_label_set_text_fmt(screen->date_text, "%s %d %s", weekday[lt->tm_wday], lt->tm_mday, month[lt->tm_mon]);
 };
 
 Screen_Clock screen_clock;


### PR DESCRIPTION
Solves #20 
- Uses rzeldent/micro-timezonedb as a local timezone database
- Switches from using the RTC to only the onboard timekeeping (not sure the rtc is really that useful unless we go to sleep)